### PR TITLE
Fix version file URL property

### DIFF
--- a/Versioning/KSP2Names.version
+++ b/Versioning/KSP2Names.version
@@ -1,6 +1,6 @@
 {
     "NAME":"KSP2Names",
-    "URL":"https://github.com/munktron239/KSP2-Names",
+    "URL":"https://raw.githubusercontent.com/munktron239/KSP2-Names/refs/heads/main/Versioning/KSP2Names.version",
     "DOWNLOAD":"https://spacedock.info/mod/3880/KSP2Names",
     "VERSION":
     {


### PR DESCRIPTION
Hi @munktron239 and @averageksp,

The `URL` property of a version file is supposed to point to an online copy of the version file. Currently it's the repo. This PR fixes it.

Noticed while reviewing KSP-CKAN/NetKAN#10527.

Cheers!
